### PR TITLE
Feature/add gp30

### DIFF
--- a/rating-core/src/lib.rs
+++ b/rating-core/src/lib.rs
@@ -106,6 +106,30 @@ fn calc_q(performance: i32, attenuation: u32) -> f64 {
     performance as f64 - S * LOG_TABLE[attenuation as usize]
 }
 
+// calculate gp30 according to https://atcoder.jp/posts/170
+pub fn calc_gp30(rank: u32) -> u32 {
+    if rank > 30 {
+        0
+    } else if rank >= 15 {
+        16 - (rank - 15)
+    } else if rank >= 10 {
+        26 - 2 * (rank - 10)
+    } else {
+        match rank {
+            1 => 100,
+            2 => 75,
+            3 => 60,
+            4 => 50,
+            5 => 45,
+            6 => 40,
+            7 => 36,
+            8 => 32,
+            9 => 29,
+            _ => 0,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -134,5 +158,14 @@ mod tests {
         let performances = [467];
         let rating = calc_rating(&performances);
         assert_eq!(rating, 39);
+    }
+
+    #[test]
+    fn calc_gp30_score() {
+        assert_eq!(calc_gp30(1), 100);
+        assert_eq!(calc_gp30(15), 16);
+        assert_eq!(calc_gp30(12), 22);
+        assert_eq!(calc_gp30(20), 11);
+        assert_eq!(calc_gp30(30), 1);
     }
 }

--- a/rating-core/src/lib.rs
+++ b/rating-core/src/lib.rs
@@ -108,25 +108,19 @@ fn calc_q(performance: i32, attenuation: u32) -> f64 {
 
 // calculate gp30 according to https://atcoder.jp/posts/170
 pub fn calc_gp30(rank: u32) -> u32 {
-    if rank > 30 {
-        0
-    } else if rank >= 15 {
-        16 - (rank - 15)
-    } else if rank >= 10 {
-        26 - 2 * (rank - 10)
-    } else {
-        match rank {
-            1 => 100,
-            2 => 75,
-            3 => 60,
-            4 => 50,
-            5 => 45,
-            6 => 40,
-            7 => 36,
-            8 => 32,
-            9 => 29,
-            _ => 0,
-        }
+    match rank {
+        1 => 100,
+        2 => 75,
+        3 => 60,
+        4 => 50,
+        5 => 45,
+        6 => 40,
+        7 => 36,
+        8 => 32,
+        9 => 29,
+        10..=14 => 26 - 2 * (rank - 10),
+        15..=30 => 16 - (rank - 15),
+        _ => 0,
     }
 }
 
@@ -167,5 +161,7 @@ mod tests {
         assert_eq!(calc_gp30(12), 22);
         assert_eq!(calc_gp30(20), 11);
         assert_eq!(calc_gp30(30), 1);
+        assert_eq!(calc_gp30(31), 0);
+        assert_eq!(calc_gp30(0), 0);
     }
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -62,6 +62,11 @@ impl User {
 }
 
 #[wasm_bindgen]
+pub fn calc_gp30_score(place: u32) -> u32 {
+    calc_gp30(place)
+}
+
+#[wasm_bindgen]
 pub fn calc_ratings(input: JsValue) -> JsValue {
     match calc_ratings_inner(input) {
         Ok(result) => serde_wasm_bindgen::to_value(&Output::new(result, "".to_string())).unwrap(),

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -3,7 +3,7 @@ mod utils;
 use anyhow::{bail, Result};
 use chrono::{DateTime, Local};
 use itertools::Itertools;
-use rating_core::{calc_gp30, calc_rating, ContestResult};
+use rating_core::{calc_gp30 as calculate_gp30, calc_rating, ContestResult};
 use serde::{Deserialize, Serialize};
 use std::cmp::Reverse;
 use wasm_bindgen::prelude::*;
@@ -62,8 +62,8 @@ impl User {
 }
 
 #[wasm_bindgen]
-pub fn calc_gp30_score(place: u32) -> u32 {
-    calc_gp30(place)
+pub fn calc_gp30(place: u32) -> u32 {
+    calculate_gp30(place)
 }
 
 #[wasm_bindgen]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -3,7 +3,7 @@ mod utils;
 use anyhow::{bail, Result};
 use chrono::{DateTime, Local};
 use itertools::Itertools;
-use rating_core::{calc_rating, ContestResult};
+use rating_core::{calc_gp30, calc_rating, ContestResult};
 use serde::{Deserialize, Serialize};
 use std::cmp::Reverse;
 use wasm_bindgen::prelude::*;
@@ -37,6 +37,7 @@ pub struct User {
     pub rank: u32,
     pub match_count: u32,
     pub win_count: u32,
+    pub gp30: u32,
     pub user_screen_name: String,
 }
 
@@ -46,6 +47,7 @@ impl User {
         rank: u32,
         match_count: u32,
         win_count: u32,
+        gp30: u32,
         user_screen_name: String,
     ) -> Self {
         Self {
@@ -53,6 +55,7 @@ impl User {
             rank,
             match_count,
             win_count,
+            gp30,
             user_screen_name,
         }
     }
@@ -95,15 +98,16 @@ fn calc_all_ratings(input: &Input) -> Vec<User> {
             let rating = calc_rating(&performances);
             let match_count = result.len() as u32;
             let win_count = result.iter().filter(|r| r.place == 1).count() as u32;
-            (rating, name, match_count, win_count)
+            let gp30 = result.iter().map(|r| calc_gp30(r.place)).sum();
+            (rating, name, match_count, win_count, gp30)
         })
-        .sorted_by_key(|&(rating, name, _, _)| (Reverse(rating), name));
+        .sorted_by_key(|&(rating, name, _, _, _)| (Reverse(rating), name));
 
     let mut rank = 1;
     let mut user_with_ranking = vec![];
     let mut prev_rating = u32::MAX;
 
-    for (i, (rating, name, match_count, win_count)) in users.enumerate() {
+    for (i, (rating, name, match_count, win_count, gp30)) in users.enumerate() {
         if rating != prev_rating {
             rank = i + 1;
         }
@@ -113,6 +117,7 @@ fn calc_all_ratings(input: &Input) -> Vec<User> {
             rank as u32,
             match_count,
             win_count,
+            gp30,
             name.to_string(),
         ));
         prev_rating = rating;

--- a/web/src/components/Individual/index.tsx
+++ b/web/src/components/Individual/index.tsx
@@ -21,6 +21,7 @@ import {
 import clsx from 'clsx';
 import dayjs from 'dayjs';
 import ordinal from 'ordinal';
+import { calc_gp30_score } from '../../../public/wasm/wasm';
 import {
   type WasmInput,
   type User,
@@ -65,6 +66,7 @@ const Individual: FC<IndividualProps> = (props) => {
         performance: convertPerformanceFromInner(result.performance),
         contestName: shortenContestName(contest.contestName),
         endDate: dayjs(contest.endTime).format('YYYY/MM/DD'),
+        gp30: calc_gp30_score(result.place),
       })),
   );
 
@@ -89,6 +91,7 @@ const Individual: FC<IndividualProps> = (props) => {
           : '';
       },
     },
+    { field: 'gp30', headerName: 'GP30', width: 80, resizable: false },
   ];
 
   const getRowId = (result: IndividualResult & { contestName: string }) => {

--- a/web/src/components/Individual/index.tsx
+++ b/web/src/components/Individual/index.tsx
@@ -136,7 +136,7 @@ const Individual: FC<IndividualProps> = (props) => {
   const showEndDate = useMediaQuery((theme: Theme) =>
     theme.breakpoints.up('sm'),
   );
-  const showGP30 = useMediaQuery((theme: Theme) => theme.breakpoints.up(450));
+  const showGp30 = useMediaQuery((theme: Theme) => theme.breakpoints.up(450));
 
   let responsiveTheme = createTheme();
   responsiveTheme = responsiveFontSizes(responsiveTheme);
@@ -203,7 +203,7 @@ const Individual: FC<IndividualProps> = (props) => {
           getRowId={getRowId}
           autoHeight
           disableColumnMenu
-          columnVisibilityModel={{ endDate: showEndDate, gp30: showGP30 }}
+          columnVisibilityModel={{ endDate: showEndDate, gp30: showGp30 }}
           pageSizeOptions={[20, 50, 100]}
         ></DataGrid>
       </Stack>

--- a/web/src/components/Individual/index.tsx
+++ b/web/src/components/Individual/index.tsx
@@ -101,8 +101,10 @@ const Individual: FC<IndividualProps> = (props) => {
 
     const rank = user?.rank !== undefined ? ordinal(user.rank) : 'Unranked';
     const rating = user?.rating ?? 0;
+    const gp30 = user?.gp30 ?? 0;
     text += `Season Ranking: ${rank}\n`;
-    text += `Season Rating: ${rating}\n\n`;
+    text += `Season Rating: ${rating}\n`;
+    text += `Season GP30: ${gp30}\n\n`;
 
     switch (period.selected) {
       case 'all':

--- a/web/src/components/Individual/index.tsx
+++ b/web/src/components/Individual/index.tsx
@@ -136,6 +136,7 @@ const Individual: FC<IndividualProps> = (props) => {
   const showEndDate = useMediaQuery((theme: Theme) =>
     theme.breakpoints.up('sm'),
   );
+  const showGP30 = useMediaQuery((theme: Theme) => theme.breakpoints.up(450));
 
   let responsiveTheme = createTheme();
   responsiveTheme = responsiveFontSizes(responsiveTheme);
@@ -202,7 +203,7 @@ const Individual: FC<IndividualProps> = (props) => {
           getRowId={getRowId}
           autoHeight
           disableColumnMenu
-          columnVisibilityModel={{ endDate: showEndDate }}
+          columnVisibilityModel={{ endDate: showEndDate, gp30: showGP30 }}
           pageSizeOptions={[20, 50, 100]}
         ></DataGrid>
       </Stack>

--- a/web/src/components/Individual/index.tsx
+++ b/web/src/components/Individual/index.tsx
@@ -21,7 +21,7 @@ import {
 import clsx from 'clsx';
 import dayjs from 'dayjs';
 import ordinal from 'ordinal';
-import { calc_gp30_score } from '../../../public/wasm/wasm';
+import { calc_gp30 } from '../../../public/wasm/wasm';
 import {
   type WasmInput,
   type User,
@@ -66,7 +66,7 @@ const Individual: FC<IndividualProps> = (props) => {
         performance: convertPerformanceFromInner(result.performance),
         contestName: shortenContestName(contest.contestName),
         endDate: dayjs(contest.endTime).format('YYYY/MM/DD'),
-        gp30: calc_gp30_score(result.place),
+        gp30: calc_gp30(result.place),
       })),
   );
 

--- a/web/src/components/Standings/index.tsx
+++ b/web/src/components/Standings/index.tsx
@@ -81,6 +81,20 @@ const Standings: FC<StandingProps> = (props) => {
       hideable: false,
       resizable: false,
     },
+    {
+      field: 'winCount',
+      headerName: '優勝数',
+      width: 100,
+      hideable: false,
+      resizable: false,
+    },
+    {
+      field: 'gp30',
+      headerName: 'GP30',
+      width: 100,
+      hideable: false,
+      resizable: false,
+    },
   ];
 
   const getRowId = (user: User) => {

--- a/web/src/components/Standings/index.tsx
+++ b/web/src/components/Standings/index.tsx
@@ -94,9 +94,13 @@ const Standings: FC<StandingProps> = (props) => {
     return user.userScreenName;
   };
 
-  const showDetail = useMediaQuery((theme: Theme) =>
-    theme.breakpoints.up('sm'),
+  const showWinCount = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.up(750),
   );
+  const showMatchCount = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.up(625),
+  );
+  const showGp30 = useMediaQuery((theme: Theme) => theme.breakpoints.up(500));
 
   return (
     <DataGrid
@@ -108,7 +112,11 @@ const Standings: FC<StandingProps> = (props) => {
       disableColumnMenu
       slots={{ toolbar: QuickSearchToolbar }}
       onRowSelectionModelChange={props.onSelectionChange}
-      columnVisibilityModel={{ matchCount: showDetail, winCount: showDetail }}
+      columnVisibilityModel={{
+        matchCount: showMatchCount,
+        winCount: showWinCount,
+        gp30: showGp30,
+      }}
     ></DataGrid>
   );
 };

--- a/web/src/components/Standings/index.tsx
+++ b/web/src/components/Standings/index.tsx
@@ -82,13 +82,6 @@ const Standings: FC<StandingProps> = (props) => {
       resizable: false,
     },
     {
-      field: 'winCount',
-      headerName: '優勝数',
-      width: 100,
-      hideable: false,
-      resizable: false,
-    },
-    {
       field: 'gp30',
       headerName: 'GP30',
       width: 100,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -37,6 +37,7 @@ export type User = {
   rank: number;
   matchCount: number;
   winCount: number;
+  gp30: number;
   userScreenName: string;
 };
 


### PR DESCRIPTION
GP30のスコアを計算して表示するようにしました
機能面での変更は大きく分けて2つで、

- リーダーボードにGP30の項目が追加されました
<img width="687" alt="スクリーンショット 2024-05-30 0 02 00" src="https://github.com/terry-u16/ahc-season-ranking/assets/92100842/4f883b5f-df72-4828-aee8-3c9e8d30a6ad">

- twitterでツイートをする際の文面にGP30の項目が追加されました

他に変更するべき場所などはないでしょうか? よろしくお願いします。